### PR TITLE
Respect record status field

### DIFF
--- a/src/octodns_netbox_dns/__init__.py
+++ b/src/octodns_netbox_dns/__init__.py
@@ -231,7 +231,8 @@ class NetBoxDNSSource(octodns.source.base.BaseSource):
             raise LookupError
 
         nb_records: pynetbox.core.response.RecordSet = self.api.plugins.netbox_dns.records.filter(
-            zone_id=nb_zone.id
+            zone_id=nb_zone.id, 
+            status='active'
         )
         for nb_record in nb_records:
             rcd_name: str = nb_record.name if nb_record.name != "@" else ""


### PR DESCRIPTION
Currently octoDNS returns all records in the configured zone, regardless of whether they are set to active or inactive.  This PR sets the filter so that only active records are returned.

I don't know for sure this is the correct approach or if it would better be configurable, but this seems most straightforward.