### PR TITLE
Always normalize zone names

### DIFF
--- a/tests/test_make_absolute.py
+++ b/tests/test_make_absolute.py
@@ -11,7 +11,7 @@ DEFAULT_CONFIG = {
 }
 
 
-def test1():
+def test_absolute():
     nbdns = NetBoxDNSProvider(**DEFAULT_CONFIG)
     rcd = "example.com"
     absolute = nbdns._make_absolute(rcd)
@@ -19,9 +19,25 @@ def test1():
     assert absolute == "example.com."
 
 
-def test2():
+def test_noop():
     nbdns = NetBoxDNSProvider(**DEFAULT_CONFIG)
     rcd = "example.com."
     absolute = nbdns._make_absolute(rcd)
+
+    assert absolute == "example.com."
+
+def test_disabled():
+    args = {**DEFAULT_CONFIG, "make_absolute": False}
+    nbdns = NetBoxDNSProvider(**args)
+    rcd = "example.com"
+    relative = nbdns._make_absolute(rcd, force=False)
+
+    assert relative == "example.com"
+
+def test_force():
+    args = {**DEFAULT_CONFIG, "make_absolute": False}
+    nbdns = NetBoxDNSProvider(**args)
+    rcd = "example.com"
+    absolute = nbdns._make_absolute(rcd, force=True)
 
     assert absolute == "example.com."


### PR DESCRIPTION
For some reason ocodns complains when zones lack a dot suffix.