### PR TITLE
caa records: convert bytes values to string

### DIFF
--- a/src/octodns_netbox_dns/__init__.py
+++ b/src/octodns_netbox_dns/__init__.py
@@ -165,8 +165,8 @@ class NetBoxDNSProvider(octodns.provider.base.BaseProvider):
             case "CAA":
                 value = {
                     "flags": rdata.flags,
-                    "tag": rdata.tag,
-                    "value": rdata.value,
+                    "tag": rdata.tag.decode(),
+                    "value": rdata.value.decode(),
                 }
 
             case "LOC":


### PR DESCRIPTION
dnspython returns the value and tag for caa records as bytes and octodns tries to set the string representation as values.

Example redacted output from octodns without this change:
```
********************************************************************************
* example.org.
********************************************************************************
* netbox (NetBoxDNSProvider)
*   Update
*     <CaaRecord CAA 300, example.org., ['0 issue "letsencrypt.org"']> ->
*     <CaaRecord CAA 300, example.org., ['0 b'issue' "b'letsencrypt.org'"']> (netbox)
*   Summary: Creates=0, Updates=1, Deletes=0, Existing Records=1
********************************************************************************
```