### PR TITLE
Make '@' values absolute

### DIFF
--- a/src/octodns_netbox_dns/__init__.py
+++ b/src/octodns_netbox_dns/__init__.py
@@ -250,7 +250,11 @@ class NetBoxDNSProvider(octodns.provider.base.BaseProvider):
         )
         for nb_record in nb_records:
             rcd_name: str = "" if nb_record.name == "@" else nb_record.name
-            rcd_value: str = nb_record.zone.name if nb_record.value == "@" else nb_record.value
+            rcd_value: str = (
+                self._make_absolute(nb_record.zone.name, True)
+                if nb_record.value == "@"
+                else nb_record.value
+            )
             rcd_type: str = nb_record.type
             rcd_ttl: int = nb_record.ttl or nb_zone.default_ttl
             if nb_record.type == "NS":


### PR DESCRIPTION
If a CNAME has an `@` value, octoDNS will complain about an invalid record because the value is missing a trailing dot. Since NetBox DNS doesn't support adding a trailing dot after `@`, this value must be absolute, regardless of the configuration of the `make_absolute` setting.