### PR TITLE
fix: Remove PTR from _include_change

### DIFF
--- a/src/octodns_netbox_dns/__init__.py
+++ b/src/octodns_netbox_dns/__init__.py
@@ -360,7 +360,7 @@ class NetBoxDNSProvider(octodns.provider.base.BaseProvider):
 
         @return: false if the change should be discarded, true if it should be kept.
         """
-        if change.record._type in ["SOA", "PTR", "NS"]:
+        if change.record._type in ["SOA", "NS"]:
             self.log.debug(rf"record not supported as provider, ignoring: {change.record}")
             return False
 


### PR DESCRIPTION
Hello,

I would like to synchronise PTR record from infoblox to netbox but unfortunately I have the following issue:
_DEBUG NetBoxDNSProvider[netbox_preprod] record not supported as provider, ignoring: <PtrRecord PTR 300, 1.1.1.1.in-addr.arpa., ['tcs.tcs.']>_

I guess this issue is related to the function _include_change.

I tested the change submitted in this PR with the following infrastructure without issue:
- netbox version: 3.7.8
- netbox DNS plugin version 0.22.8

Here is the result
_2025-02-12T14:36:16  [139906302902272] DEBUG Zone changes: zone=Zone<1.1.1.in-addr.arpa.>, create record=<PtrRecord PTR 300, 1.1.1.1.in-addr.arpa., ['tcs.tcs.']>
2025-02-12T14:36:16  [139906302902272] DEBUG Plan __init__: Creates=1, Updates=0, Deletes=0 Existing=0
2025-02-12T14:36:16  [139906302902272] INFO  NetBoxDNSProvider[netbox_preprod] plan:   Creates=1, Updates=0, Deletes=0, Existing Records=0
2025-02-12T14:36:16  [139906302902272] INFO  Plan
1.1.1.in-addr.arpa.
 netbox_preprod (NetBoxDNSProvider)
 Create <PtrRecord PTR 300, 1.1.1.1.in-addr.arpa., ['tcs.tcs.']> (infoblox)
 Summary: Creates=1, Updates=0, Deletes=0, Existing Records=0_

Could you explain me why this function has been include in this plugin in version v0.3.4?

Thank you for your time