### PR TITLE
Silently ignore SOA records

### DIFF
--- a/src/octodns_netbox_dns/__init__.py
+++ b/src/octodns_netbox_dns/__init__.py
@@ -224,6 +224,10 @@ class NetBoxDNSProvider(octodns.provider.base.BaseProvider):
                 self.log.debug(f"'{rcd_type}' record type not implemented. ignoring record")
                 raise NotImplementedError
 
+            # Silently ignore SOA records as required by NetBox DNS, but not supported by octoDNS.
+            case "SOA":
+                raise NotImplementedError
+
             case _:
                 self.log.error(f"ignoring invalid record with type: '{rcd_type}'")
                 raise NotImplementedError

--- a/src/octodns_netbox_dns/__init__.py
+++ b/src/octodns_netbox_dns/__init__.py
@@ -220,12 +220,8 @@ class NetBoxDNSProvider(octodns.provider.base.BaseProvider):
                     "target": self._make_absolute(rdata.target.to_text()),
                 }
 
-            case "ALIAS" | "DS" | "NAPTR" | "SPF" | "TLSA" | "URLFWD":
+            case "ALIAS" | "DS" | "NAPTR" | "SPF" | "TLSA" | "URLFWD" | "SOA":
                 self.log.debug(f"'{rcd_type}' record type not implemented. ignoring record")
-                raise NotImplementedError
-
-            # Silently ignore SOA records as required by NetBox DNS, but not supported by octoDNS.
-            case "SOA":
                 raise NotImplementedError
 
             case _:


### PR DESCRIPTION
NetBox automatically manages an SOA record for zones. These are not supported by octoDNS. To avoid misleading error messages in the log, SOA records are silently ignored.