### PR TITLE
Make NS TTL handling configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ providers:
         # Make CNAME, MX and SRV records absolute if they are missing the trailing "."
         # [optional, default=false]
         make_absolute: false
+        # Control how NS TTL is derived when reading from NetBox.
+        # soa_refresh -> preserve the current behavior and use the zone's soa_refresh for all NS
+        # record      -> use the record TTL stored in NetBox, falling back to zone.default_ttl
+        # fixed       -> use ns_ttl_value for apex NS and record/default TTL for delegated NS
+        # [optional, default=soa_refresh]
+        ns_ttl_mode: soa_refresh
+        # TTL value used when ns_ttl_mode=fixed for apex NS records.
+        # [optional, default=14400]
+        ns_ttl_value: 14400
         # Disable automatic PTR record creating in the NetboxDNS plugin.
         # [optional, default=true]
         disable_ptr: true

--- a/src/octodns_netbox_dns/__init__.py
+++ b/src/octodns_netbox_dns/__init__.py
@@ -48,6 +48,8 @@ class NetBoxDNSProvider(octodns.provider.base.BaseProvider):
         view: str | None | Literal[False] = None,
         replace_duplicates: bool = False,
         make_absolute: bool = False,
+        ns_ttl_mode: Literal["soa_refresh", "record", "fixed"] = "soa_refresh",
+        ns_ttl_value: int = 14400,
         disable_ptr: bool = True,
         insecure_request: bool = False,
         zone_status_filter: str = "active",
@@ -70,6 +72,8 @@ class NetBoxDNSProvider(octodns.provider.base.BaseProvider):
         self.nb_view = self._get_nb_view(view)
         self.replace_duplicates = replace_duplicates
         self.make_absolute = make_absolute
+        self.ns_ttl_mode = ns_ttl_mode
+        self.ns_ttl_value = ns_ttl_value
         self.disable_ptr = disable_ptr
         self.zone_status_filter = {"status": zone_status_filter} if zone_status_filter else {}
         self.record_status_filter = {"status": record_status_filter} if record_status_filter else {}
@@ -77,6 +81,20 @@ class NetBoxDNSProvider(octodns.provider.base.BaseProvider):
 
         _init_info = {k: v for k, v in locals().items() if k not in ["self", "__class__", "token"]}
         self.log.debug(f"__init__: {_init_info}")
+        config_parts = [
+            f"view={view}",
+            f"ns_ttl_mode={self.ns_ttl_mode}",
+        ]
+        if self.ns_ttl_mode == "fixed":
+            config_parts.append(f"ns_ttl_value={self.ns_ttl_value}")
+        config_parts.extend(
+            [
+                f"zone_status_filter={zone_status_filter}",
+                f"record_status_filter={record_status_filter}",
+                f"max_page_size={self.max_page_size}",
+            ]
+        )
+        self.log.info("config: %s", " ".join(config_parts))
 
     def _make_absolute(self, value: str, force: bool = False) -> str:
         """Return dns name with trailing dot to make it absolute.
@@ -106,6 +124,25 @@ class NetBoxDNSProvider(octodns.provider.base.BaseProvider):
         fixed = value.replace(r"\\", "\\").replace(r"\;", ";")
         self.log.debug(rf"in='{value}', unescaped='{fixed}'")
         return fixed
+
+    def _record_ttl(
+        self,
+        nb_zone: pynetbox.core.response.Record,
+        nb_record: pynetbox.core.response.Record,
+    ) -> int:
+        ttl = int(nb_record.ttl or nb_zone.default_ttl)
+        if nb_record.type != "NS":
+            return ttl
+
+        if self.ns_ttl_mode == "soa_refresh":
+            return int(nb_zone.soa_refresh)
+        if self.ns_ttl_mode == "record":
+            return ttl
+        if self.ns_ttl_mode == "fixed":
+            return self.ns_ttl_value if nb_record.name == "@" else ttl
+
+        msg = f"invalid ns_ttl_mode={self.ns_ttl_mode}"
+        raise ValueError(msg)
 
     def _get_nb_view(self, view: str | None | Literal[False]) -> dict[str, int]:
         """Get the correct netbox view.
@@ -264,9 +301,7 @@ class NetBoxDNSProvider(octodns.provider.base.BaseProvider):
                 else nb_record.value
             )
             rcd_type: str = nb_record.type
-            rcd_ttl: int = nb_record.ttl or nb_zone.default_ttl
-            if nb_record.type == "NS":
-                rcd_ttl = nb_zone.soa_refresh
+            rcd_ttl: int = self._record_ttl(nb_zone, nb_record)
 
             rcd_data = {
                 "name": rcd_name,

--- a/tests/test_ns_ttl.py
+++ b/tests/test_ns_ttl.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+from typing import Literal
+
+from octodns_netbox_dns import NetBoxDNSProvider
+
+
+def _provider(
+    ns_ttl_mode: Literal["soa_refresh", "record", "fixed"] = "soa_refresh",
+    ns_ttl_value: int = 14400,
+) -> NetBoxDNSProvider:
+    return NetBoxDNSProvider(
+        id=1,
+        url="https://localhost:8000",
+        token="",
+        view=False,
+        replace_duplicates=False,
+        make_absolute=True,
+        ns_ttl_mode=ns_ttl_mode,
+        ns_ttl_value=ns_ttl_value,
+    )
+
+
+def test_ns_ttl_mode_soa_refresh() -> None:
+    provider = _provider(ns_ttl_mode="soa_refresh")
+    zone = SimpleNamespace(default_ttl=3600, soa_refresh=600)
+    record = SimpleNamespace(type="NS", ttl=86400, name="@")
+
+    assert provider._record_ttl(zone, record) == 600
+
+
+def test_ns_ttl_mode_record() -> None:
+    provider = _provider(ns_ttl_mode="record")
+    zone = SimpleNamespace(default_ttl=3600, soa_refresh=600)
+    record = SimpleNamespace(type="NS", ttl=86400, name="@")
+
+    assert provider._record_ttl(zone, record) == 86400
+
+
+def test_ns_ttl_mode_fixed_for_apex_ns() -> None:
+    provider = _provider(ns_ttl_mode="fixed", ns_ttl_value=14400)
+    zone = SimpleNamespace(default_ttl=3600, soa_refresh=600)
+    record = SimpleNamespace(type="NS", ttl=86400, name="@")
+
+    assert provider._record_ttl(zone, record) == 14400
+
+
+def test_ns_ttl_mode_fixed_preserves_non_apex_ns() -> None:
+    provider = _provider(ns_ttl_mode="fixed", ns_ttl_value=14400)
+    zone = SimpleNamespace(default_ttl=3600, soa_refresh=600)
+    record = SimpleNamespace(type="NS", ttl=3600, name="delegated")
+
+    assert provider._record_ttl(zone, record) == 3600
+
+
+def test_non_ns_records_use_record_ttl() -> None:
+    provider = _provider(ns_ttl_mode="fixed", ns_ttl_value=14400)
+    zone = SimpleNamespace(default_ttl=3600, soa_refresh=600)
+    record = SimpleNamespace(type="A", ttl=7200, name="@")
+
+    assert provider._record_ttl(zone, record) == 7200


### PR DESCRIPTION
## Summary

Add configurable NS TTL handling for `NetBoxDNSProvider`.

This introduces:
- `ns_ttl_mode=soa_refresh|record|fixed`
- `ns_ttl_value` for `fixed` mode

Default behavior remains unchanged with `ns_ttl_mode=soa_refresh`.

## Why

Currently NS records are always emitted with `nb_zone.soa_refresh` as TTL.

That couples two unrelated values:
- SOA refresh
- NS TTL

In practice this can create unexpected diffs such as:
- `60 -> 300`
- `172800 -> 600`
- `86400 -> 10000`

This change keeps the current behavior as the default, but allows users to:
- use record/default TTLs with `ns_ttl_mode=record`
- use a fixed apex NS TTL with `ns_ttl_mode=fixed`

## Included

- provider implementation update
- README documentation
- tests for the new modes
- startup config logging for the active NS TTL mode

## Tested with

- octoDNS 1.15.0
- octodns-netbox-dns 0.3.15
- octodns-powerdns 1.0.0


## Backward compatibility

Default behavior is unchanged.
