### PR TITLE
feat(threading): add threading parameter into provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ providers:
     # A value of 0 means: show every item. Can cause errors with the NetBox setting: MAX_PAGE_SIZE
     # [optional, default=0]
     max_page_size: 0
+    # Threading 
+    # Allow multi threading, useful for large dns zones, see https://github.com/netbox-community/pynetbox#threading :
+    # [optional, default=False]
+    enable_threading: False
 ```
 
 ## compatibility

--- a/src/octodns_netbox_dns/__init__.py
+++ b/src/octodns_netbox_dns/__init__.py
@@ -58,7 +58,7 @@ class NetBoxDNSProvider(octodns.provider.base.BaseProvider):
         zone_status_filter: str = "active",
         record_status_filter: str = "active",
         max_page_size: int = 0,
-        enable_threading: bool = False, # control pynetbox's multithread feature
+        enable_threading: bool = False,  # control pynetbox's multithread feature
         *args,
         **kwargs,
     ) -> None:

--- a/src/octodns_netbox_dns/__init__.py
+++ b/src/octodns_netbox_dns/__init__.py
@@ -58,6 +58,7 @@ class NetBoxDNSProvider(octodns.provider.base.BaseProvider):
         zone_status_filter: str = "active",
         record_status_filter: str = "active",
         max_page_size: int = 0,
+        enable_threading: bool = False, # control pynetbox's multithread feature
         *args,
         **kwargs,
     ) -> None:
@@ -66,7 +67,7 @@ class NetBoxDNSProvider(octodns.provider.base.BaseProvider):
 
         super().__init__(id, *args, **kwargs)
 
-        self.api = Api(url, token)
+        self.api = Api(url, token, threading=enable_threading)
         if insecure_request:
             import urllib3  # noqa: PLC0415
 


### PR DESCRIPTION
# PR description

Enable the threading capability from the pynetbox library. This feature improves performance particularly on large DNS zones. 

Comparison : 

```shell
# Sync from local netbox instance with max page size set to 1000

#enable_threading: False 

2026-05-06T08:26:36  [8313690304] INFO    NetBoxDNSProvider[netbox] provider config: {'id': 'netbox', 'url': 'http://127.0.0.1:8005/', 'view': None, 'replace_duplicates': False, 'make_absolute': False, 'ns_ttl_mode': 'soa_refresh', 'ns_ttl_value': 14400, 'disable_ptr': True, 'insecure_request': False, 'enable_threading': False, 'zone_status_filter': 'active', 'record_status_filter': 'active', 'max_page_size': 0, 'args': (), 'kwargs': {}}

#5k records read complete in 4 sec

2026-05-06T08:26:36  [8313690304] INFO    NetBoxDNSProvider[netbox] --> populate '5krecords.tld.', target=False, lenient=False
2026-05-06T08:26:40  [8313690304] INFO    NetBoxDNSProvider[netbox] populate -> found 5000 records for zone '5krecords.tld.'

# 10k record  read complete in 9s

2026-05-06T08:26:41  [8313690304] INFO    NetBoxDNSProvider[netbox] --> populate '10krecords.tld.', target=False, lenient=False
2026-05-06T08:26:50  [8313690304] INFO    NetBoxDNSProvider[netbox] populate -> found 10000 records for zone '10krecords.tld.'

# 25k record took in 25 sec

2026-05-06T08:26:52  [8313690304] INFO    NetBoxDNSProvider[netbox] --> populate '25krecords.tld.', target=False, lenient=False
2026-05-06T08:27:17  [8313690304] INFO    NetBoxDNSProvider[netbox] populate -> found 25000 records for zone '25krecords.tld.'

#enable_threading: True

2026-05-06T08:23:01  [8313690304] INFO    NetBoxDNSProvider[netbox] provider config: {'id': 'netbox', 'url': 'http://127.0.0.1:8005/', 'view': None, 'replace_duplicates': False, 'make_absolute': False, 'ns_ttl_mode': 'soa_refresh', 'ns_ttl_value': 14400, 'disable_ptr': True, 'insecure_request': False, 'enable_threading': True, 'zone_status_filter': 'active', 'record_status_filter': 'active', 'max_page_size': 0, 'args': (), 'kwargs': {}}

#5k records read complete in 3 sec

2026-05-06T08:23:01  [8313690304] INFO    NetBoxDNSProvider[netbox] --> populate '5krecords.tld.', target=False, lenient=False
2026-05-06T08:23:04  [8313690304] INFO    NetBoxDNSProvider[netbox] populate -> found 5000 records for zone '5krecords.tld.'
 
# 10k record  read complete in 3s

2026-05-06T08:23:05  [8313690304] INFO    NetBoxDNSProvider[netbox] --> populate '10krecords.tld.', target=False, lenient=False
2026-05-06T08:23:08  [8313690304] INFO    NetBoxDNSProvider[netbox] populate -> found 10000 records for zone '10krecords.tld.'

# 25k record took in 8 sec

2026-05-06T08:23:10  [8313690304] INFO    NetBoxDNSProvider[netbox] --> populate '25krecords.tld.', target=False, lenient=False
2026-05-06T08:23:18  [8313690304] INFO    NetBoxDNSProvider[netbox] populate -> found 25000 records for zone '25krecords.tld.'
```