### PR TITLE
feat: add support for TLSA records

### DIFF
--- a/dev/zones/example.com.yaml
+++ b/dev/zones/example.com.yaml
@@ -74,6 +74,13 @@ sshfp1:
     algorithm: 4
     fingerprint: 123456789abcdef67890123456789abcdef67890123456789abcdef123456789
     fingerprint_type: 2
+tlsa1:
+  type: TLSA
+  value:
+    certificate_usage: 1
+    selector: 1
+    matching_type: 2
+    certificate_association_data: 123456789abcdef67890123456789abcdef67890123456789abcdef123456789
 txt1:
   type: TXT
   value: v=TLSRPTv1\; rua=mailto:tlsrpt@example.com

--- a/src/octodns_netbox_dns/__init__.py
+++ b/src/octodns_netbox_dns/__init__.py
@@ -38,7 +38,7 @@ class NetBoxDNSProvider(octodns.provider.base.BaseProvider):
         "SRV",
         "SSHFP",
         # "SVCB",
-        # "TLSA",
+        "TLSA",
         "TXT",
         # "URLFWD",
     }
@@ -259,7 +259,15 @@ class NetBoxDNSProvider(octodns.provider.base.BaseProvider):
                     "target": self._make_absolute(rdata.target.to_text()),
                 }
 
-            case "ALIAS" | "DS" | "NAPTR" | "SPF" | "TLSA" | "URLFWD" | "SOA":
+            case "TLSA":
+                value = {
+                    "certificate_usage": rdata.usage,
+                    "selector": rdata.selector,
+                    "matching_type": rdata.mtype,
+                    "certificate_association_data": rdata.cert.hex(),
+                }
+
+            case "ALIAS" | "DS" | "NAPTR" | "SPF" | "URLFWD" | "SOA":
                 self.log.debug(f"'{rcd_type}' record type not implemented. ignoring record")
                 raise NotImplementedError
 

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -147,7 +147,15 @@ def test_sshfp() -> None:
 
 
 def test_tlsa() -> None:
-    pass  # not supported
+    rcd_type = "TLSA"
+    rcd_value = "1 1 2 abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+    value = nbdns._format_rdata(rcd_type, rcd_value)
+    assert value == {
+        "certificate_usage": 1,
+        "selector": 1,
+        "matching_type": 2,
+        "certificate_association_data": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+    }
 
 
 def test_txt1() -> None:


### PR DESCRIPTION
Enable TLSA in the provider's SUPPORTS set and add a _format_rdata handler that maps DNSPython rdata fields (usage, selector, mtype, cert) to the octoDNS TlsaValue format (certificate_usage, selector, matching_type, certificate_association_data). The write path is already covered by the generic ValuesMixin branch in _format_changeset.

- Add TLSA case in _format_rdata and remove it from the NotImplementedError fallback
- Replace the no-op test_tlsa with a real round-trip assertion
- Add a tlsa1 example to the dev integration zone fixture