### PR TITLE
Add support to SVCB and HTTPS RR

### DIFF
--- a/src/octodns_netbox_dns/__init__.py
+++ b/src/octodns_netbox_dns/__init__.py
@@ -6,6 +6,7 @@ import octodns.provider.base
 import octodns.provider.plan
 import octodns.record
 import octodns.zone
+from dns.rdtypes.svcbbase import ParamKey
 from pynetbox.core.api import Api
 from pynetbox.core.response import Record, RecordSet
 
@@ -27,7 +28,7 @@ class NetBoxDNSProvider(octodns.provider.base.BaseProvider):
         "CNAME",
         "DNAME",
         # "DS",
-        # "HTTPS",
+        "HTTPS",
         "LOC",
         "MX",
         # "NAPTR",
@@ -37,7 +38,7 @@ class NetBoxDNSProvider(octodns.provider.base.BaseProvider):
         # "SPF",
         "SRV",
         "SSHFP",
-        # "SVCB",
+        "SVCB",
         "TLSA",
         "TXT",
         # "URLFWD",
@@ -186,6 +187,40 @@ class NetBoxDNSProvider(octodns.provider.base.BaseProvider):
 
         return nb_zone
 
+    def _format_svcparams(self, params: Any) -> dict[str, Any]:
+        """Convert dnspython SVCB/HTTPS params to the octodns svcparams dict.
+
+        @param params: the `params` mapping from a parsed SVCB/HTTPS rdata
+
+        @return: a dict mapping svcparam keys to None, str or list values
+        """
+        svcparams: dict[str, Any] = {}
+        for key, param in params.items():
+            try:
+                name = ParamKey(key).name.lower().replace("_", "-")
+            except ValueError:
+                name = f"key{int(key)}"
+
+            if param is None:
+                svcparams[name] = None
+                continue
+
+            match name:
+                case "alpn":
+                    svcparams[name] = [v.decode() for v in param.ids]
+                case "mandatory":
+                    svcparams[name] = [
+                        ParamKey(k).name.lower().replace("_", "-") for k in param.keys
+                    ]
+                case "ipv4hint" | "ipv6hint":
+                    svcparams[name] = [str(a) for a in param.addresses]
+                case "port":
+                    svcparams[name] = str(param.port)
+                case _:
+                    svcparams[name] = param.to_text().strip('"')
+
+        return svcparams
+
     def _format_rdata(self, rcd_type: str, rcd_value: str) -> str | dict[str, Any]:
         """Format netbox record values to correct octodns record values.
 
@@ -265,6 +300,13 @@ class NetBoxDNSProvider(octodns.provider.base.BaseProvider):
                     "selector": rdata.selector,
                     "matching_type": rdata.mtype,
                     "certificate_association_data": rdata.cert.hex(),
+                }
+
+            case "SVCB" | "HTTPS":
+                value = {
+                    "svcpriority": rdata.priority,
+                    "targetname": self._make_absolute(rdata.target.to_text()),
+                    "svcparams": self._format_svcparams(rdata.params),
                 }
 
             case "ALIAS" | "DS" | "NAPTR" | "SPF" | "URLFWD" | "SOA":

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -146,6 +146,56 @@ def test_sshfp() -> None:
     }
 
 
+def test_svcb_alias_mode() -> None:
+    rcd_type = "SVCB"
+    rcd_value = "0 svc.example.com."
+    value = nbdns._format_rdata(rcd_type, rcd_value)
+
+    assert value == {
+        "svcpriority": 0,
+        "targetname": "svc.example.com.",
+        "svcparams": {},
+    }
+
+
+def test_svcb_service_mode() -> None:
+    rcd_type = "SVCB"
+    rcd_value = (
+        "1 svc.example.com. mandatory=alpn,port alpn=h2,h3 port=8443 "
+        "ipv4hint=192.0.2.1,192.0.2.2 ipv6hint=2001:db8::1 no-default-alpn ech=AED+CAAA"
+    )
+    value = nbdns._format_rdata(rcd_type, rcd_value)
+
+    assert value == {
+        "svcpriority": 1,
+        "targetname": "svc.example.com.",
+        "svcparams": {
+            "mandatory": ["alpn", "port"],
+            "alpn": ["h2", "h3"],
+            "port": "8443",
+            "ipv4hint": ["192.0.2.1", "192.0.2.2"],
+            "ipv6hint": ["2001:db8::1"],
+            "no-default-alpn": None,
+            "ech": "AED+CAAA",
+        },
+    }
+
+
+def test_https() -> None:
+    rcd_type = "HTTPS"
+    rcd_value = "1 example.com. alpn=h2,h3 port=443"
+    value = nbdns._format_rdata(rcd_type, rcd_value)
+
+    assert value == {
+        "svcpriority": 1,
+        "targetname": "example.com.",
+        "svcparams": {
+            "alpn": ["h2", "h3"],
+            "port": "443",
+        },
+    }
+
+
 def test_tlsa() -> None:
     rcd_type = "TLSA"
     rcd_value = "1 1 2 abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"


### PR DESCRIPTION

Adds support for `SVCB` and `HTTPS` resource records (RFC 9460) to the
NetBox DNS provider.

Both record types are already supported by netbox-plugin-dns (any
dns.rdatatype.RdataType is a valid record type), and octodns has
first-class SvcbRecord / HttpsRecord classes — this PR wires the two
together by adding read/write conversion in NetBoxDNSProvider.

## What's covered

- AliasMode (svcpriority == 0, no svcparams) and ServiceMode records
- All RFC 9460 SvcParams:
  - mandatory, alpn, no-default-alpn, port,
    ipv4hint, ipv6hint, ech
- Unknown keyNNN params fall through via dnspython's GenericParam

## References

- [RFC 9460 — Service Binding and Parameter Specification via the DNS (SVCB and HTTPS Resource Records)](https://datatracker.ietf.org/doc/html/rfc9460)